### PR TITLE
xsetup_cmd invocation, after X start

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -285,6 +285,7 @@ void App::Run() {
 
 		CreateServerAuth();
 		StartServer();
+		SetupServer();
 #endif
 
 	}
@@ -982,6 +983,14 @@ int App::StartServer() {
 	serverStarted = true;
 
 	return ServerPID;
+}
+
+int App::SetupServer() {
+	string setupCommand = cfg->getOption("xsetup_cmd");
+	if (setupCommand != "")
+		logStream << APPNAME << ": Setting X up, using " << setupCommand << ": ";
+		int rc = system(setupCommand.c_str());
+		logStream << WEXITSTATUS(rc) << endl;
 }
 
 jmp_buf CloseEnv;

--- a/app.h
+++ b/app.h
@@ -72,6 +72,7 @@ private:
 
 	/* Server functions */
 	int StartServer();
+	int SetupServer();
 	int ServerTimeout(int timeout, char *string);
 	int WaitForServer();
 

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -32,6 +32,7 @@ Cfg::Cfg()
 	options.insert(option("default_path","/bin:/usr/bin:/usr/local/bin"));
 	options.insert(option("default_xserver","/usr/bin/X"));
 	options.insert(option("xserver_arguments",""));
+	options.insert(option("xsetup_cmd",""));
 	options.insert(option("numlock",""));
 	options.insert(option("daemon",""));
 	options.insert(option("xauth_path","/usr/bin/xauth"));

--- a/slim.conf
+++ b/slim.conf
@@ -3,6 +3,7 @@
 default_path        /bin:/usr/bin:/usr/local/bin
 default_xserver     /usr/bin/X
 #xserver_arguments   -dpi 75
+#xsetup_cmd          /path/to/xrandr/script
 
 # Commands for halt, login, etc.
 halt_cmd            /sbin/shutdown -h now


### PR DESCRIPTION
To avoid black screen and enable Optimus configuration, it is required to issue XrandR commands after X started, such as:

> xrandr --setprovideroutputsource modesetting NVIDIA-0
> xrandr --auto

Here is a quick hack adding xsetup_cmd configuration entry to achieve this.
